### PR TITLE
added count to favourite in dashboard

### DIFF
--- a/app/views/dashboards/_favorites.html.erb
+++ b/app/views/dashboards/_favorites.html.erb
@@ -1,5 +1,5 @@
 <div>
-<h4>Favourite Items...</h4>
+<p>Favourite Itineraries (<%= @favorite_itineraries.count %>)</p>
   <% @favorite_itineraries.each do |favourite_itinerary| %>
   <div class="d-flex flex-column">
     <h2><strong><%= favourite_itinerary.itinerary.title %></strong></h2>

--- a/app/views/dashboards/show.html.erb
+++ b/app/views/dashboards/show.html.erb
@@ -9,7 +9,8 @@
       <a class="nav-link" id="pills-open-tab" data-toggle="pill" href="#pills-open" role="tab" aria-controls="pills-open" aria-selected="false">Open listing ()</a>
     </li>
     <li class="nav-item">
-      <a class="nav-link" id="pills-favourites-tab" data-toggle="pill" href="#pills-favourites" role="tab" aria-controls="pills-favourites" aria-selected="false">Favourites ()</a>
+      <a class="nav-link" id="pills-favourites-tab" data-toggle="pill" href="#pills-favourites" role="tab" aria-controls="pills-favourites" aria-selected="false">Favourites (<%= @favorite_itineraries.count %>)</a>
+      <!-- count will need updating once favourite events and users are added -->
     </li>
   </ul>
 


### PR DESCRIPTION
Favourites in dashboard now counts number of favourite itineraries (will need updating once we add favourite events and users to include these).

Added a favourite itineraries header with the count.