### PR TITLE
Fix bug and dry render destroy

### DIFF
--- a/app/controllers/event_favorites_controller.rb
+++ b/app/controllers/event_favorites_controller.rb
@@ -6,7 +6,7 @@ class EventFavoritesController < ApplicationController
   def create
     if !current_user
       flash[:alert] = 'You need to be logged in to add a favorite event!'
-      render js: "window.location = '/users/sign_in"
+      render js: "window.location = '/users/sign_in'"
       return
     end
 
@@ -24,7 +24,7 @@ class EventFavoritesController < ApplicationController
 
     respond_to do |format|
       format.html { redirect_to @event }
-      format.js
+      format.js { render action: :create }
     end
   end
 

--- a/app/controllers/favorite_itineraries_controller.rb
+++ b/app/controllers/favorite_itineraries_controller.rb
@@ -6,7 +6,7 @@ class FavoriteItinerariesController < ApplicationController
   def create
     if !current_user
       flash[:alert] = 'You need to be logged in to add a favorite itinerary!'
-      render js: "window.location = '/users/sign_in"
+      render js: "window.location = '/users/sign_in'"
       return
     end
 
@@ -24,7 +24,7 @@ class FavoriteItinerariesController < ApplicationController
 
     respond_to do |format|
       format.html { redirect_to @itinerary }
-      format.js
+      format.js { render action: :create }
     end
   end
 

--- a/app/views/event_favorites/destroy.js.erb
+++ b/app/views/event_favorites/destroy.js.erb
@@ -1,2 +1,0 @@
-var eventFavoriteHeart = document.querySelector('.event-heart-icon[data-event-id="<%= @event.id %>"]');
-eventFavoriteHeart.innerHTML = '<%= j render "events/heart", event: @event %>'

--- a/app/views/favorite_itineraries/destroy.js.erb
+++ b/app/views/favorite_itineraries/destroy.js.erb
@@ -1,2 +1,0 @@
-var favoriteItineraryHeart = document.querySelector('.itinerary-heart-icon[data-itinerary-id="<%= @itinerary.id %>"]');
-favoriteItineraryHeart.innerHTML = '<%= j render "itineraries/heart", itinerary: @itinerary %>'


### PR DESCRIPTION
# fix the bug, when new users trying to favourite an itinerary,  but are not able to be redirected to sing_in pg. 

# clean code with render action of destroy