### PR TITLE
fixed the spots_left method

### DIFF
--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -34,9 +34,10 @@ class Event < ApplicationRecord
 
   def spots_left
     if !max_spots.nil?
-      approved = EventRegistration.where(event_id: id) && EventRegistration.where(status: 1).count
-      total = max_spots - approved + 1
-      total > 0 ? total : 0
+      approved = EventRegistration.where(status: 1).where(event_id: id).count
+      # approved = EventRegistration.where(event_id: id) && EventRegistration.where(status: 1).count
+      total = max_spots - approved
+      total > 0 ? total || total : 0
     end
   end
 


### PR DESCRIPTION
Managed to work out why the count of available spots was incorrect and we had to put the hacky -1 in the spots_left method.
The line for "approved" was producing the incorrect result, instead of using && we have to chain the .where, also have to search for status: 1 then the event_id.
 Replaced: approved= EventRegistration.where(event_id: id) && EventRegistration.where(status: 1).count
with:  approved = EventRegistration.where(status: 1).where(event_id: id).count
Had to use a byebug to work it out.
Also changed the last line of the method to:
      total > 0 ? total || total : 0
You might think it's overkill but I was thinking it would prevent negative totals from showing.